### PR TITLE
Add geobuf support for big geojson segmentation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ There are currently available the following commands:
   - `-data=</path/to/images/folder>` : example -> -data=/home/lab/pipeline/data. **OBS**: this is the data folder
   - `-include_marker_images=<yes or no or list of present specific markers to display as image layers>` : example -> -include_marker_images=DAPI,SST,GORASP2. **OBS**: this includes the specified markers as image layers in the TissUUmaps project. If this is not set, no image layers will be included
   - `-include_geojson=<yes or no to include cell segmentation as regions>` : example -> -include_geojson=yes. **OBS**: this includes the cell segmentation as regions in the TissUUmaps project. If this is not set, no regions will be included
+  - `-compress_geojson=<yes or no to compress geojson regions into pbf>` : example -> -compress_geojson=yes. **OBS**: this includes the cell segmentation regions as a compressed pbf file
   - `-include_html=<yes or no to export html page for sharing the TissUUmaps project on the web>` : example -> -include_marker_images=yes. **OBS**: this includes the html page for sharing the TissUUmaps project on the web. A web server is needed to visualize the exported web page
   
 *Example 2*: contents of `pipex_batch_list.txt` for the images from *example 1*
@@ -178,7 +179,7 @@ There are currently available the following commands:
 
     generate_geojson.py -data=/home/lab/pipeline/data -expand=yes
 
-    generate_tissuumaps.py -data=/home/lab/pipeline/data -include_marker_images=DAPI,CDH1,HLA-DR,CHGA,KRT5 -include_geojson=yes -include_html=yes
+    generate_tissuumaps.py -data=/home/lab/pipeline/data -include_marker_images=DAPI,CDH1,HLA-DR,CHGA,KRT5 -include_geojson=yes -compress_geojson -include_html=yes
 </code>
 
 

--- a/generate_tissuumaps.py
+++ b/generate_tissuumaps.py
@@ -15,8 +15,14 @@ compress_geojson = "no"
 include_html = "no"
 
 def exporting_tissuumaps ():
+    # Check if the required files are present
     if include_marker_images == "no" and include_geojson == "yes":
         print(">>> Impossible to display geojson without a background image", flush=True)
+        include_geojson = "no"
+    if include_geojson == "yes":
+        if not os.path.exists(os.path.join(data_folder, 'analysis/cell_segmentation_geo.json')):
+            print(">>> Impossible to display geojson without a cell segmentation file", flush=True)
+            include_geojson = "no"
     
     adata = sc.read_h5ad(os.path.join(data_folder, 'analysis/downstream/anndata.h5ad'))
 

--- a/pipexGUI.py
+++ b/pipexGUI.py
@@ -72,7 +72,8 @@ tooltip_46 = '<optional, file path to a pre-made custom segmentation>`: \nexampl
 tooltip_47 = '<optional, yes or no to refine the cluster results through cell_types.csv data>: \nexample -> yes'
 tooltip_48 = '<optional, yes or no or list of present specific markers to display as image layers> : example -> DAPI,SST,GORASP2'
 tooltip_49 = '<optional, yes or no to include cell segmentation as regions> : example -> yes'
-tooltip_50 = '<optional, yes or no to export html page for sharing the TissUUmaps project on the web> : example -> yes'
+tooltip_50 = '<optional, yes or no to compress geojson regions into pbf> : example -> yes'
+tooltip_51 = '<optional, yes or no to export html page for sharing the TissUUmaps project on the web> : example -> yes'
 
 
 
@@ -152,7 +153,8 @@ column = [[sg.Text('PIPEX data folder:', font='any 12'), sg.In(default_text=data
           [sg.Text(' NOTE: requires previous \'QuPath GeoJSON\' results if you want to include regions', pad=((20,0), (0,0)))],
           [sg.Text('  - Include marker images, comma-separated:', s=(35,1), pad=((20,0), (0,0))), sg.Input(default_text='',s=40,disabled=True, key='-TISSUUMAPS_MARKER-'), sg.Image(data=info_icon,subsample=3,tooltip=tooltip_48)],
           [sg.Text('  - Include regions', pad=((20,0), (0,0))), sg.Checkbox('',key='-TISSUUMAPS_REGION-', disabled=True, enable_events=True, default=False), sg.Image(data=info_icon,subsample=3,tooltip=tooltip_49)],
-          [sg.Text('  - Include html', pad=((20,0), (0,0))), sg.Checkbox('',key='-TISSUUMAPS_HTML-', disabled=True, enable_events=True, default=False), sg.Image(data=info_icon,subsample=3,tooltip=tooltip_50)]]
+          [sg.Text('  - Compress regions', pad=((20,0), (0,0))), sg.Checkbox('',key='-TISSUUMAPS_COMPRESS_REGIONS-', disabled=True, enable_events=True, default=False), sg.Image(data=info_icon,subsample=3,tooltip=tooltip_50)],
+          [sg.Text('  - Include html', pad=((20,0), (0,0))), sg.Checkbox('',key='-TISSUUMAPS_HTML-', disabled=True, enable_events=True, default=False), sg.Image(data=info_icon,subsample=3,tooltip=tooltip_51)]]
 
 layout = [[sg.Column(column, scrollable=True,  vertical_scroll_only=True, size=(620,700))],
           [sg.Text('_'*85)],
@@ -277,6 +279,7 @@ while True:
     if event == '-TISSUUMAPS-':
         window['-TISSUUMAPS_MARKER-'].update(disabled=(not values['-TISSUUMAPS-']))
         window['-TISSUUMAPS_REGION-'].update(disabled=(not values['-TISSUUMAPS-']))
+        window['-TISSUUMAPS_COMPRESS_REGIONS-'].update(disabled=(not values['-TISSUUMAPS-']))
         window['-TISSUUMAPS_HTML-'].update(disabled=(not values['-TISSUUMAPS-']))
 
 window.close()
@@ -399,6 +402,7 @@ if values['-TISSUUMAPS-']:
         'generate_tissuumaps.py -data=' + batch_data +
         ' -include_marker_images=' + values['-TISSUUMAPS_MARKER-'] +
         ' -include_geojson=' + ('yes' if values['-TISSUUMAPS_REGION-'] else 'no') +
+        ' -compress_geojson=' + ('yes' if values['-TISSUUMAPS_COMPRESS_REGIONS-'] else 'no') +
         ' -include_html=' + ('yes' if values['-TISSUUMAPS_HTML-'] else 'no'))
 
 if (batch_list != ''):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ opencv-python==4.5.5.64
 pandas==2.1.3
 Pillow==10.1.0
 protobuf==3.20.3
+geobuf
 psutil==5.9.0
 PySimpleGUI==4.60.5
 qnorm==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ opencv-python==4.5.5.64
 pandas==2.1.3
 Pillow==10.1.0
 protobuf==3.20.3
-geobuf
+geobuf==1.1.1
 psutil==5.9.0
 PySimpleGUI==4.60.5
 qnorm==0.8.1


### PR DESCRIPTION
Adding a new parameter `-compress_geojson` to `generate_tissuumaps.py`.
If `-compress_geojson=yes`, then these additional steps will be computed:
 - read `analysis/cell_segmentation_geo.json`
 - remove measurements
 - approximate region boundaries (to get less points per cell border)
 - save as geobuf (see https://github.com/mapbox/geobuf)
 - include the geobuf file in the TissUUmaps project

If `-compress_geojson=no` (default), the `cell_segmentation_geo.json` file will be included as is in the TissUUmaps project.

We also check that the geojson file exists before we generate the TissUUmaps project, to avoid error during static export.

Note that this PR updates the requirements to add the geobuf dependency.